### PR TITLE
Add 1 to centre tap in reverse_fir()

### DIFF
--- a/src/common-filters.c
+++ b/src/common-filters.c
@@ -134,7 +134,7 @@ void reverse_fir(double *fir, int length)
 	for (i = 0; i < length; i++)
 		fir[i] = -1.0 * fir[i];
 
-	fir[length - 1] += 1.0;
+	fir[length / 2] += 1.0;
 }
 
 /*	Algorithm taken form:


### PR DESCRIPTION
While adapting this code to use in my own project, I felt sure there was something wrong with reverse_fir().

High pass filter should, I think, invert all coefficients of low pass filter, then add 1 to the centre tap, not the last tap.

Prepared to be told I've missed something blindingly obvious :)